### PR TITLE
ExpansionTile Allows Customizable Rotating Trailing

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -40,6 +40,7 @@ class ExpansionTile extends StatefulWidget {
     this.onExpansionChanged,
     this.children = const <Widget>[],
     this.trailing,
+    this.rotateTrailing,
     this.initiallyExpanded = false,
     this.maintainState = false,
     this.tilePadding,
@@ -85,8 +86,13 @@ class ExpansionTile extends StatefulWidget {
   /// The color to display behind the sublist when expanded.
   final Color? backgroundColor;
 
-  /// A widget to display instead of a rotating arrow icon.
+  /// A widget to display instead of an arrow icon.
   final Widget? trailing;
+
+  /// Specifies if the trailing should rotate (true) or not (false).
+  ///
+  /// When the value is null the trailing will rotate, unless a custom [trailing] is passed.
+  final bool? rotateTrailing;
 
   /// Specifies if the list tile is initially expanded (true) or collapsed (false, the default).
   final bool initiallyExpanded;
@@ -212,6 +218,8 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
 
   Widget _buildChildren(BuildContext context, Widget? child) {
     final Color borderSideColor = _borderColor.value ?? Colors.transparent;
+    final Widget trailing = widget.trailing ?? const Icon(Icons.expand_more);
+    final bool rotateTrailing = widget.rotateTrailing ?? widget.trailing == null;
 
     return Container(
       decoration: BoxDecoration(
@@ -233,10 +241,10 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
               leading: widget.leading,
               title: widget.title,
               subtitle: widget.subtitle,
-              trailing: widget.trailing ?? RotationTransition(
+              trailing: rotateTrailing ? RotationTransition(
                 turns: _iconTurns,
-                child: const Icon(Icons.expand_more),
-              ),
+                child: trailing,
+              ) : trailing,
             ),
           ),
           ClipRect(

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -481,4 +481,42 @@ void main() {
     expect(columnRect.bottom, paddingRect.bottom - 4);
   });
 
+  testWidgets('ExpansionTile default trailing default rotation', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: SingleChildScrollView(
+          child: Column(
+            children: const <Widget>[
+              ExpansionTile(
+                title: Text('default trailing => will rotate'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+    expect(find.byType(RotationTransition), findsOneWidget);
+  });
+
+  final Key customIconKey = UniqueKey();
+
+  testWidgets('ExpansionTile custom trailing default rotation', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: SingleChildScrollView(
+          child: Column(
+            children: <Widget>[
+              ExpansionTile(
+                title: const Text('custom trailing => won\t rotate'),
+                trailing: TestIcon(key: customIconKey),
+              ),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+    expect(find.byType(RotationTransition), findsNothing);
+  });
 }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -499,6 +499,44 @@ void main() {
     expect(find.byType(RotationTransition), findsOneWidget);
   });
 
+  testWidgets('ExpansionTile default trailing no rotation', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: SingleChildScrollView(
+          child: Column(
+            children: const <Widget>[
+              ExpansionTile(
+                title: Text('default trailing, won\'t rotate'),
+                rotateTrailing: false,
+              ),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+    expect(find.byType(RotationTransition), findsNothing);
+  });
+
+  testWidgets('ExpansionTile default trailing with rotation', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: SingleChildScrollView(
+          child: Column(
+            children: const <Widget>[
+              ExpansionTile(
+                title: Text('default trailing, will rotate'),
+                rotateTrailing: true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+    expect(find.byType(RotationTransition), findsOneWidget);
+  });
+
   final Key customIconKey = UniqueKey();
 
   testWidgets('ExpansionTile custom trailing default rotation', (WidgetTester tester) async {
@@ -518,5 +556,45 @@ void main() {
     ));
 
     expect(find.byType(RotationTransition), findsNothing);
+  });
+
+  testWidgets('ExpansionTile custom trailing no rotation', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: SingleChildScrollView(
+          child: Column(
+            children: <Widget>[
+              ExpansionTile(
+                title: const Text('custom trailing, won\t rotate'),
+                trailing: TestIcon(key: customIconKey),
+                rotateTrailing: false,
+              ),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+    expect(find.byType(RotationTransition), findsNothing);
+  });
+
+  testWidgets('ExpansionTile custom trailing with rotation', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: SingleChildScrollView(
+          child: Column(
+            children: <Widget>[
+              ExpansionTile(
+                title: const Text('custom trailing, will rotate'),
+                trailing: TestIcon(key: customIconKey),
+                rotateTrailing: true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+    expect(find.byType(RotationTransition), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Description
Currently, `ExpansionTile` allows passing a widget to be used as trailing, which will replace the one that is created internally. The bad news is that there is no way to maintain the `RotationTransition` that the widget provides the default trailing when the tile expands after a tap. The transition cannot even be passed from the outside, as its implementation makes use of private information (`_iconTurns`). So it is either custom trailing or rotating default trailing.

This PR adds an optional nullable parameter of type `bool` to the widget, to control the rotation of the trailing. 

This decoupling of the widget from its rotation allows the caller to have an ExpansionTile with any of the following:
- a default trailing, rotating (previously supported);
- a default trailing, fixed (now supported);
- a custom trailing, fixed (previously supported);
- a default trailing, rotating (now supported).

When the parameter is set to null or not specified, the original default behavior is preserved:
- if `trailing` is provided, then no rotation is applied.
- if no `trailing` is provided, then the default trailing will rotate.

## Related Issues
Fixes #69401 

## Tests

I added the following tests:
- **`ExpansionTile default trailing default rotation`** - creates an ExpansionTile, with `trailing` and `rotateTrailing` set to defaults, and tests if the widget contains a `RotationTransition`.  
- **`ExpansionTile default trailing no rotation`** - creates an ExpansionTile, with `trailing` set to default and `rotateTrailing` set to `false`, and tests if the widget does not contain a `RotationTransition`.
- **`ExpansionTile default trailing with rotation`** - creates an ExpansionTile, with `trailing` set to default and `rotateTrailing` set to `true`, and tests if the widget contains a `RotationTransition`.
- **`ExpansionTile custom trailing default rotation`** - creates an ExpansionTile, with `trailing` set to a custom widget and `rotateTrailing` set to default, and tests if the widget does not contain a `RotationTransition`.
- **`ExpansionTile custom trailing no rotation`** - creates an ExpansionTile, with `trailing` set to a custom widget and `rotateTrailing` set to `false`, and tests if the widget does not contain a `RotationTransition`.
- **`ExpansionTile custom trailing with rotation`** - creates an ExpansionTile, with `trailing` set to a custom widget and `rotateTrailing` set to `true`, and tests if the widget contains a `RotationTransition`.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
